### PR TITLE
Make graph.pos compatible with labeltext as list

### DIFF
--- a/R/forestplot.R
+++ b/R/forestplot.R
@@ -439,12 +439,12 @@ forestplot.default <- function (labeltext,
                   " The only values accepted are 'left'/'right' or 'first'/'last'.",
                   " You have provided the value '", graph.pos, "'"))
   }else if(is.numeric(graph.pos)){
-    if (!graph.pos %in% 1:(NCOL(labeltext) + 1))
-      stop("The graph position must be between 1 and ", (NCOL(labeltext) + 1), ".",
+    if (!graph.pos %in% 1:(nc + 1))
+      stop("The graph position must be between 1 and ", (nc + 1), ".",
            " You have provided the value '", graph.pos, "'.")
   }else{
     stop("The graph pos must either be a string consisting of 'left'/'right' (alt. 'first'/'last')",
-         ", or an integer value between 1 and ", (NCOL(labeltext) + 1))
+         ", or an integer value between 1 and ", (nc + 1))
   }
 
   # Prepare the summary and align variables

--- a/tests/testthat/test-graph-pos.R
+++ b/tests/testthat/test-graph-pos.R
@@ -1,0 +1,41 @@
+library(testthat)
+context("Test for graph.pos range")
+
+test_that("Test for graph.pos compatibility with labeltext as list",{
+  pseudomat <- list(Author=list("Smith et al", "Smith et al"), Year=list(2002,2005), N=list(50,75), Weight=list(0.40,0.60))
+  mat <- cbind(1:2, 0:1, 4:5)
+  expect_silent(forestplot(labeltext = pseudomat, mean=mat, graph.pos="first"))
+  expect_silent(forestplot(labeltext = pseudomat, mean=mat, graph.pos="last"))
+  expect_silent(forestplot(labeltext = pseudomat, mean=mat, graph.pos=1))
+  expect_silent(forestplot(labeltext = pseudomat, mean=mat, graph.pos=4))
+  expect_silent(forestplot(labeltext = pseudomat, mean=mat, graph.pos=5))
+  expect_error(forestplot(labeltext = pseudomat, mean=mat, graph.pos=6))
+  expect_error(forestplot(labeltext = pseudomat, mean=mat, graph.pos=0))
+  expect_error(forestplot(labeltext = pseudomat, mean=mat, graph.pos=-5))
+})
+
+test_that("Test for graph.pos compatibility with labeltext as matrix",{
+  pseudomat <- cbind(Author=c("Smith et al", "Smith et al"), Year=c(2002,2005), N=c(50,75), Weight=c(0.40,0.60))
+  mat <- cbind(1:2, 0:1, 4:5)
+  expect_silent(forestplot(labeltext = pseudomat, mean=mat, graph.pos="first"))
+  expect_silent(forestplot(labeltext = pseudomat, mean=mat, graph.pos="last"))
+  expect_silent(forestplot(labeltext = pseudomat, mean=mat, graph.pos=1))
+  expect_silent(forestplot(labeltext = pseudomat, mean=mat, graph.pos=4))
+  expect_silent(forestplot(labeltext = pseudomat, mean=mat, graph.pos=5))
+  expect_error(forestplot(labeltext = pseudomat, mean=mat, graph.pos=6))
+  expect_error(forestplot(labeltext = pseudomat, mean=mat, graph.pos=0))
+  expect_error(forestplot(labeltext = pseudomat, mean=mat, graph.pos=-5))
+})
+
+
+test_that("Test for graph.pos compatibility with labeltext as vector",{
+  pseudomat <- c("Smith et al", "Smith et al")
+  mat <- cbind(1:2, 0:1, 4:5)
+  expect_silent(forestplot(labeltext = pseudomat, mean=mat, graph.pos="first"))
+  expect_silent(forestplot(labeltext = pseudomat, mean=mat, graph.pos="last"))
+  expect_silent(forestplot(labeltext = pseudomat, mean=mat, graph.pos=1))
+  expect_silent(forestplot(labeltext = pseudomat, mean=mat, graph.pos=2))
+  expect_error(forestplot(labeltext = pseudomat, mean=mat, graph.pos=3))
+  expect_error(forestplot(labeltext = pseudomat, mean=mat, graph.pos=0))
+  expect_error(forestplot(labeltext = pseudomat, mean=mat, graph.pos=-5))
+})


### PR DESCRIPTION
Fix the bug that made the number of columns of labeltext improperly
counted when it was a list of list, making it impossible to choose a
numeric graph.pos together with labeltext as a list of list.
Fixes issue #30 