### PR TITLE
2.0 version

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -7,3 +7,4 @@ cran-comments.md
 ^.vscode
 ^doc$
 ^Meta$
+^cran-comments\.md$

--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,5 @@ doc
 Meta
 revdep
 .vscode
+/doc/
+/Meta/

--- a/NEWS.md
+++ b/NEWS.md
@@ -61,7 +61,7 @@ Changes for 1.3
 Changes for 1.2
 ---------------
 * Line-type can be specified
-* Line endings can now be marked by a T vertice, this default for all line types other than 1
+* Line endings can now be marked by a T vertical, this default for all line types other than 1
 * The arrow height defaults to the same height as the vertices
 * Added a grid option
 * Improved documentation

--- a/R/assertAndRetrieveTidyValue.R
+++ b/R/assertAndRetrieveTidyValue.R
@@ -1,6 +1,6 @@
-#' Retriever of tidyselect
+#' Retriever of `tidyselect`
 #'
-#' As forestpot has evolved we now primarily use tidyverse select style. This
+#' As forestpot has evolved we now primarily use `tidyverse` select style. This
 #' function helps with backward compatibility
 #'
 #' @param x The data with the potential value

--- a/R/forestplot-package.R
+++ b/R/forestplot-package.R
@@ -21,7 +21,7 @@
 #' @section Additional functions:
 #'
 #' The \code{\link{getTicks}} tries to format ticks for plots in a nicer way.
-#' The major use is for exponentials where ticks are generated using the
+#' The major use is for exponential form where ticks are generated using the
 #' \eqn{2^n} since a doubling is a concept easy to grasp for less mathematical-savvy
 #' readers.
 #'

--- a/R/forestplot.R
+++ b/R/forestplot.R
@@ -17,7 +17,7 @@
 #' Using multiple bands, i.e. multiple lines, per variable can be interesting when
 #' you want to compare different outcomes. E.g. if you want to compare survival
 #' specific to heart disease to overall survival for smoking it may be useful to
-#' have two bands on top of eachother. Another useful implementation is to show
+#' have two bands on top of each other. Another useful implementation is to show
 #' crude and adjusted estimates as separate bands.
 #'
 #' @section Horizontal lines:
@@ -76,29 +76,29 @@
 #'   the value is a summary value which means that it will have a different
 #'   font-style
 #' @param graph.pos The position of the graph element within the table of text. The
-#'   position can be \code{1-(ncol(labeltext) + 1)}. You can also choose set the positin
+#'   position can be \code{1-(ncol(labeltext) + 1)}. You can also choose set the position
 #'   to \code{"left"} or \code{"right"}.
 #' @param hrzl_lines Add horizontal lines to graph. Can either be \code{TRUE} or a \code{list}
 #'   of \code{\link[grid]{gpar}}. See line section below for details.
 #' @param clip Lower and upper limits for clipping confidence intervals to arrows
 #' @param xlab x-axis label
 #' @param zero x-axis coordinate for zero line. If you provide a vector of length 2 it
-#'   will print a rectangle instead of just a line. If you provide NA the line is supressed.
+#'   will print a rectangle instead of just a line. If you provide NA the line is suppressed.
 #' @param graphwidth Width of confidence interval graph, see \code{\link[grid]{unit}} for
 #'   details on how to utilize mm etc. The default is \code{auto}, that is it uses up whatever
 #'   space that is left after adjusting for text size and legend
 #' @param colgap Sets the gap between columns, defaults to 6 mm but for relative widths.
 #'   Note that the value should be in \code{\link[grid]{unit}(,"npc")}.
-#' @param lineheight Height of the graph. By default this is \code{auto} and adjustes to the
+#' @param lineheight Height of the graph. By default this is \code{auto} and adjusts to the
 #'   space that is left after adjusting for x-axis size and legend. Sometimes
-#'   it might be desireable to set the line height to a certain height, for
+#'   it might be desirable to set the line height to a certain height, for
 #'   instance if you have several forestplots you may want to standardize their
 #'   line height, then you set this variable to a certain height, note this should
 #'   be provided as a \code{\link[grid]{unit}} object. A good option
 #'   is to set the line height to \code{unit(2, "cm")}. A third option
 #'   is to set line height to "lines" and then you get 50 \% more than what the
 #'   text height is as your line height
-#' @param line.margin Set the margin between rows, provided in numeric or \code{\link[grid]{unit}} formar.
+#' @param line.margin Set the margin between rows, provided in numeric or \code{\link[grid]{unit}} form.
 #'   When having multiple confidence lines per row setting the correct
 #'   margin in order to visually separate rows
 #' @param col Set the colors for all the elements. See \code{\link{fpColors}} for

--- a/R/forestplot.default.R
+++ b/R/forestplot.default.R
@@ -170,7 +170,7 @@ forestplot.default <- function(labeltext,
         (!missing(clip) && any(clip <= 0, na.rm = TRUE)) ||
         (!missing(grid) && any(grid <= 0, na.rm = TRUE))) {
       stop("All argument values (mean, lower, upper, zero, grid and clip)",
-           " should be provided as exponentials when using the log scale.",
+           " should be provided in exponential form when using the log scale.",
            " This is an intentional break with the original forestplot function in order",
            " to simplify other arguments such as ticks, clips, and more.")
     }

--- a/R/forestplot_helpers.R
+++ b/R/forestplot_helpers.R
@@ -438,7 +438,7 @@ fpDrawPointCI <- function(lower_limit,
 }
 
 #' @rdname fpDrawCI
-#' @param col The color of the summary objecct
+#' @param col The color of the summary object
 #' @export
 fpDrawSummaryCI <- function(lower_limit, estimate, upper_limit,
                             size, col, y.offset = 0.5,
@@ -792,7 +792,7 @@ prMergeGp <- function(weak = gpar(), strong = gpar()) {
 #' \code{\link{forestplot}} function. This is in order to limit the crowding
 #' among the arguments for the \code{\link{forestplot}} call.
 #'
-#' @param pos The position of the legend, either at the "top" or the "right" unlesss
+#' @param pos The position of the legend, either at the "top" or the "right" unless
 #'  positioned inside the plot. If you want the legend to be positioned inside the plot
 #'  then you have to provide a list with the same x & y qualities as \code{\link[graphics]{legend}}.
 #'  For instance if you want the legend to be positioned at the top right corner then
@@ -839,7 +839,7 @@ fpLegend <- function(pos           = "top",
 #'
 #' You can provide a \code{list} of elements for the \code{label}
 #' and \code{summary} in order to specify separate elements. If you
-#' provide a \code{list} in one dimension the \code{gpar} elements are assummed
+#' provide a \code{list} in one dimension the \code{gpar} elements are assumed
 #' to follow the columns. If you provide a \code{list} of 2 dimensions the
 #' structure assumes is \code{list[[row]][[column]]} and the number of elements
 #' should correspond to the number of labels for the \code{label} argument, i.e.

--- a/R/private.R
+++ b/R/private.R
@@ -576,7 +576,7 @@ prFpPrintLabels <- function(labels, nc, nr, graph.pos) {
   }
 }
 
-#' An alternativ to rep()
+#' An alternative to rep()
 #'
 #' The rep() doesn't work with length.out
 #' when lists are supposed to be their own
@@ -587,7 +587,7 @@ prFpPrintLabels <- function(labels, nc, nr, graph.pos) {
 #' @return \code{list}
 #' @keywords internal
 prListRep <- function(x, length.out) {
-  lapply(0:(length.out-1),
+  lapply(0:(length.out - 1),
          function(x, g) {
            if (!is.list(g) ||
                  !is.list(g[[1]]))
@@ -866,18 +866,18 @@ prFpFetchRowLabel <- function(label_type, labeltext, i, j) {
   return(row_column_text)
 }
 
-#' Get the main foresplot
+#' Get the main `forestplot`
 #'
 #' The layout makes space for a legend if needed
 #'
 #' @param labels The labels
 #' @param nr Number of rows
 #' @param legend_layout A legend layout object if applicable
-#' @return \code{viewport} Returns the viewport needed
+#' @return \code{viewport} Returns the `viewport` needed
 #'
 #' @inheritParams forestplot
 #' @keywords internal
-prFpGetLayoutVP <- function (lineheight, labels, nr, legend_layout = NULL) {
+prFpGetLayoutVP <- function(lineheight, labels, nr, legend_layout = NULL) {
   if (!is.unit(lineheight)) {
     if (lineheight == "auto") {
       lvp_height <- unit(1, "npc")
@@ -1258,7 +1258,7 @@ prGridPlotTitle <- function(title,
   pushViewport(viewport(layout.pos.row = 3, name = "main"))
 }
 
-#' Just a simple acces to the gp$cex parameter
+#' Just a simple access to the gp$cex parameter
 #'
 #' @param x The text-grob of interest
 #' @return \code{numeric} The cex value, 1 if no cex was present

--- a/man/assertAndRetrieveTidyValue.Rd
+++ b/man/assertAndRetrieveTidyValue.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/assertAndRetrieveTidyValue.R
 \name{assertAndRetrieveTidyValue}
 \alias{assertAndRetrieveTidyValue}
-\title{Retriever of tidyselect}
+\title{Retriever of `tidyselect`}
 \usage{
 assertAndRetrieveTidyValue(
   x,
@@ -24,6 +24,6 @@ assertAndRetrieveTidyValue(
 value with attribute
 }
 \description{
-As forestpot has evolved we now primarily use tidyverse select style. This
+As forestpot has evolved we now primarily use `tidyverse` select style. This
 function helps with backward compatibility
 }

--- a/man/forestplot-package.Rd
+++ b/man/forestplot-package.Rd
@@ -28,7 +28,7 @@ The forestplot:
 
 
 The \code{\link{getTicks}} tries to format ticks for plots in a nicer way.
-The major use is for exponentials where ticks are generated using the
+The major use is for exponential form where ticks are generated using the
 \eqn{2^n} since a doubling is a concept easy to grasp for less mathematical-savvy
 readers.
 }

--- a/man/forestplot.Rd
+++ b/man/forestplot.Rd
@@ -99,7 +99,7 @@ font-style}
 \item{align}{Vector giving alignment (l,r,c) for the table columns}
 
 \item{graph.pos}{The position of the graph element within the table of text. The
-position can be \code{1-(ncol(labeltext) + 1)}. You can also choose set the positin
+position can be \code{1-(ncol(labeltext) + 1)}. You can also choose set the position
 to \code{"left"} or \code{"right"}.}
 
 \item{hrzl_lines}{Add horizontal lines to graph. Can either be \code{TRUE} or a \code{list}
@@ -110,7 +110,7 @@ of \code{\link[grid]{gpar}}. See line section below for details.}
 \item{xlab}{x-axis label}
 
 \item{zero}{x-axis coordinate for zero line. If you provide a vector of length 2 it
-will print a rectangle instead of just a line. If you provide NA the line is supressed.}
+will print a rectangle instead of just a line. If you provide NA the line is suppressed.}
 
 \item{graphwidth}{Width of confidence interval graph, see \code{\link[grid]{unit}} for
 details on how to utilize mm etc. The default is \code{auto}, that is it uses up whatever
@@ -119,9 +119,9 @@ space that is left after adjusting for text size and legend}
 \item{colgap}{Sets the gap between columns, defaults to 6 mm but for relative widths.
 Note that the value should be in \code{\link[grid]{unit}(,"npc")}.}
 
-\item{lineheight}{Height of the graph. By default this is \code{auto} and adjustes to the
+\item{lineheight}{Height of the graph. By default this is \code{auto} and adjusts to the
 space that is left after adjusting for x-axis size and legend. Sometimes
-it might be desireable to set the line height to a certain height, for
+it might be desirable to set the line height to a certain height, for
 instance if you have several forestplots you may want to standardize their
 line height, then you set this variable to a certain height, note this should
 be provided as a \code{\link[grid]{unit}} object. A good option
@@ -129,7 +129,7 @@ is to set the line height to \code{unit(2, "cm")}. A third option
 is to set line height to "lines" and then you get 50 \% more than what the
 text height is as your line height}
 
-\item{line.margin}{Set the margin between rows, provided in numeric or \code{\link[grid]{unit}} formar.
+\item{line.margin}{Set the margin between rows, provided in numeric or \code{\link[grid]{unit}} form.
 When having multiple confidence lines per row setting the correct
 margin in order to visually separate rows}
 
@@ -237,7 +237,7 @@ See \code{vignette("forestplot")} for details.
 Using multiple bands, i.e. multiple lines, per variable can be interesting when
 you want to compare different outcomes. E.g. if you want to compare survival
 specific to heart disease to overall survival for smoking it may be useful to
-have two bands on top of eachother. Another useful implementation is to show
+have two bands on top of each other. Another useful implementation is to show
 crude and adjusted estimates as separate bands.
 }
 

--- a/man/fpDrawCI.Rd
+++ b/man/fpDrawCI.Rd
@@ -156,7 +156,7 @@ This is used together with shapes_gp to retrieve graphical parameters for that i
 
 \item{pch}{Type of point see \code{\link[grid]{grid.points}} for details}
 
-\item{col}{The color of the summary objecct}
+\item{col}{The color of the summary object}
 }
 \value{
 \code{void} The function outputs the line using grid compatible

--- a/man/fpLegend.Rd
+++ b/man/fpLegend.Rd
@@ -13,7 +13,7 @@ fpLegend(
 )
 }
 \arguments{
-\item{pos}{The position of the legend, either at the "top" or the "right" unlesss
+\item{pos}{The position of the legend, either at the "top" or the "right" unless
 positioned inside the plot. If you want the legend to be positioned inside the plot
 then you have to provide a list with the same x & y qualities as \code{\link[graphics]{legend}}.
 For instance if you want the legend to be positioned at the top right corner then

--- a/man/fpTxtGp.Rd
+++ b/man/fpTxtGp.Rd
@@ -37,7 +37,7 @@ Elements not specified inherit their default settings from the
 
 You can provide a \code{list} of elements for the \code{label}
 and \code{summary} in order to specify separate elements. If you
-provide a \code{list} in one dimension the \code{gpar} elements are assummed
+provide a \code{list} in one dimension the \code{gpar} elements are assumed
 to follow the columns. If you provide a \code{list} of 2 dimensions the
 structure assumes is \code{list[[row]][[column]]} and the number of elements
 should correspond to the number of labels for the \code{label} argument, i.e.

--- a/man/prFpDrawLegend.Rd
+++ b/man/prFpDrawLegend.Rd
@@ -28,7 +28,7 @@ of all shapes drawn (squares, lines, diamonds, etc.). This overrides \code{col},
 
 \item{colgap}{The gap between the box and the text}
 
-\item{pos}{The position of the legend, either at the "top" or the "right" unlesss
+\item{pos}{The position of the legend, either at the "top" or the "right" unless
 positioned inside the plot. If you want the legend to be positioned inside the plot
 then you have to provide a list with the same x & y qualities as \code{\link[graphics]{legend}}.
 For instance if you want the legend to be positioned at the top right corner then

--- a/man/prFpDrawLines.Rd
+++ b/man/prFpDrawLines.Rd
@@ -15,7 +15,7 @@ of \code{\link[grid]{gpar}}. See line section below for details.}
 \item{colwidths}{Vector with column widths}
 
 \item{graph.pos}{The position of the graph element within the table of text. The
-position can be \code{1-(ncol(labeltext) + 1)}. You can also choose set the positin
+position can be \code{1-(ncol(labeltext) + 1)}. You can also choose set the position
 to \code{"left"} or \code{"right"}.}
 }
 \description{

--- a/man/prFpGetGraphTicksAndClips.Rd
+++ b/man/prFpGetGraphTicksAndClips.Rd
@@ -59,7 +59,7 @@ for details}
 \item{clip}{Lower and upper limits for clipping confidence intervals to arrows}
 
 \item{zero}{x-axis coordinate for zero line. If you provide a vector of length 2 it
-will print a rectangle instead of just a line. If you provide NA the line is supressed.}
+will print a rectangle instead of just a line. If you provide NA the line is suppressed.}
 
 \item{x_range}{The range that the values from the different confidence
 interval span}
@@ -67,7 +67,7 @@ interval span}
 \item{mean}{The original means, either matrix or vector}
 
 \item{graph.pos}{The position of the graph element within the table of text. The
-position can be \code{1-(ncol(labeltext) + 1)}. You can also choose set the positin
+position can be \code{1-(ncol(labeltext) + 1)}. You can also choose set the position
 to \code{"left"} or \code{"right"}.}
 
 \item{shapes_gp}{Sets graphical parameters (squares and lines widths, styles, etc.)

--- a/man/prFpGetLayoutVP.Rd
+++ b/man/prFpGetLayoutVP.Rd
@@ -2,14 +2,14 @@
 % Please edit documentation in R/private.R
 \name{prFpGetLayoutVP}
 \alias{prFpGetLayoutVP}
-\title{Get the main foresplot}
+\title{Get the main `forestplot`}
 \usage{
 prFpGetLayoutVP(lineheight, labels, nr, legend_layout = NULL)
 }
 \arguments{
-\item{lineheight}{Height of the graph. By default this is \code{auto} and adjustes to the
+\item{lineheight}{Height of the graph. By default this is \code{auto} and adjusts to the
 space that is left after adjusting for x-axis size and legend. Sometimes
-it might be desireable to set the line height to a certain height, for
+it might be desirable to set the line height to a certain height, for
 instance if you have several forestplots you may want to standardize their
 line height, then you set this variable to a certain height, note this should
 be provided as a \code{\link[grid]{unit}} object. A good option
@@ -24,7 +24,7 @@ text height is as your line height}
 \item{legend_layout}{A legend layout object if applicable}
 }
 \value{
-\code{viewport} Returns the viewport needed
+\code{viewport} Returns the `viewport` needed
 }
 \description{
 The layout makes space for a legend if needed

--- a/man/prFpGetLegendBoxPosition.Rd
+++ b/man/prFpGetLegendBoxPosition.Rd
@@ -7,7 +7,7 @@
 prFpGetLegendBoxPosition(pos)
 }
 \arguments{
-\item{pos}{The position of the legend, either at the "top" or the "right" unlesss
+\item{pos}{The position of the legend, either at the "top" or the "right" unless
 positioned inside the plot. If you want the legend to be positioned inside the plot
 then you have to provide a list with the same x & y qualities as \code{\link[graphics]{legend}}.
 For instance if you want the legend to be positioned at the top right corner then

--- a/man/prFpPrintLabels.Rd
+++ b/man/prFpPrintLabels.Rd
@@ -14,7 +14,7 @@ prFpPrintLabels(labels, nc, nr, graph.pos)
 \item{nr}{Number of rows}
 
 \item{graph.pos}{The position of the graph element within the table of text. The
-position can be \code{1-(ncol(labeltext) + 1)}. You can also choose set the positin
+position can be \code{1-(ncol(labeltext) + 1)}. You can also choose set the position
 to \code{"left"} or \code{"right"}.}
 }
 \value{

--- a/man/prFpXrange.Rd
+++ b/man/prFpXrange.Rd
@@ -16,7 +16,7 @@ to be the same format as the mean.}
 \item{clip}{Lower and upper limits for clipping confidence intervals to arrows}
 
 \item{zero}{x-axis coordinate for zero line. If you provide a vector of length 2 it
-will print a rectangle instead of just a line. If you provide NA the line is supressed.}
+will print a rectangle instead of just a line. If you provide NA the line is suppressed.}
 
 \item{xticks}{Optional user-specified x-axis tick marks. Specify NULL to use
 the defaults, numeric(0) to omit the x-axis. By adding a labels-attribute,

--- a/man/prGetTextGrobCex.Rd
+++ b/man/prGetTextGrobCex.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/private.R
 \name{prGetTextGrobCex}
 \alias{prGetTextGrobCex}
-\title{Just a simple acces to the gp$cex parameter}
+\title{Just a simple access to the gp$cex parameter}
 \usage{
 prGetTextGrobCex(x)
 }
@@ -13,6 +13,6 @@ prGetTextGrobCex(x)
 \code{numeric} The cex value, 1 if no cex was present
 }
 \description{
-Just a simple acces to the gp$cex parameter
+Just a simple access to the gp$cex parameter
 }
 \keyword{internal}

--- a/man/prListRep.Rd
+++ b/man/prListRep.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/private.R
 \name{prListRep}
 \alias{prListRep}
-\title{An alternativ to rep()}
+\title{An alternative to rep()}
 \usage{
 prListRep(x, length.out)
 }

--- a/tests/testthat/test-inputs.R
+++ b/tests/testthat/test-inputs.R
@@ -1,6 +1,6 @@
 library(testthat)
 library(abind)
-context("Tests for foresplot inputs")
+context("Tests for forestplot inputs")
 
 test_that("Check different input formats",{
   basic_data <- cbind(0:2,1:3,2:4)

--- a/vignettes/forestplot.Rmd
+++ b/vignettes/forestplot.Rmd
@@ -224,10 +224,12 @@ Altering fonts
 Altering fonts may give a completely different feel to the table:
 
 ```{r}
+# Priority order of fonts allow us to be a little flexible, if HersheyScript doesn't exist we fall back on Helvetica
+font <- list("HersheyScript", "Helvetica", "Consolas")
 dfHRQoL %>% 
   filter(group == "Sweden") %>% 
   forestplot(labeltext = c(labeltext, est), 
-             txt_gp = fpTxtGp(label = gpar(fontfamily = "HersheyScript")),
+             txt_gp = fpTxtGp(label = gpar(fontfamily = font)),
              col = clrs,
              xlab = "EQ-5D index")
 ```
@@ -238,7 +240,7 @@ There is also the possibility of being selective in gp-styles:
 dfHRQoL %>% 
   filter(group == "Sweden") %>% 
   forestplot(labeltext = c(labeltext, est), 
-             txt_gp = fpTxtGp(label = list(gpar(fontfamily = "HersheyScript"),
+             txt_gp = fpTxtGp(label = list(gpar(fontfamily = rev(font)),
                                            gpar(fontfamily = "",
                                                 col = "#660000")),
                               ticks = gpar(fontfamily = "", cex = 1),

--- a/vignettes/forestplot.Rmd
+++ b/vignettes/forestplot.Rmd
@@ -182,7 +182,7 @@ cochrane_output_df %>%
 Positioning the graph element
 -----------------------------
 
-You can also choose to have the graph positioned within the text table by specifying the *graph.pos* argument:
+You can also choose to have the graph positioned within the text table by specifying the `graph.pos` argument:
 
 ```{r}
 cochrane_output_df %>% 
@@ -278,7 +278,7 @@ dfHRQoL %>%
              xlab = "EQ-5D index")
 ```
 
-If you want to keep the relative sizes you need to provide a wrapper to the draw function that transforms the boxes. Below shows how this is done, also how you combine multiple foresplots into one image:
+If you want to keep the relative sizes you need to provide a wrapper to the draw function that transforms the boxes. Below shows how this is done, also how you combine multiple forestplots into one image:
 
 ```{r fig.width=10, fig.height=4}
 library(grid)
@@ -428,7 +428,7 @@ dfHRQoL %>%
              xlab = "EQ-5D index")
 ```
 
-By adding a "labels" attribute to the ticks you can tailor the ticks even further, here's an example the supresses tick text for every other tick:
+By adding a "labels" attribute to the ticks you can tailor the ticks even further, here's an example the suppresses tick text for every other tick:
 
 ```{r}
 xticks <- seq(from = -.1, to = .05, by = 0.025)

--- a/vignettes/forestplot.Rmd
+++ b/vignettes/forestplot.Rmd
@@ -225,11 +225,10 @@ Altering fonts may give a completely different feel to the table:
 
 ```{r}
 # Priority order of fonts allow us to be a little flexible, if HersheyScript doesn't exist we fall back on Helvetica
-font <- list("HersheyScript", "Helvetica", "Consolas")
 dfHRQoL %>% 
   filter(group == "Sweden") %>% 
   forestplot(labeltext = c(labeltext, est), 
-             txt_gp = fpTxtGp(label = gpar(fontfamily = font)),
+             txt_gp = fpTxtGp(label = gpar(fontfamily = "mono")),
              col = clrs,
              xlab = "EQ-5D index")
 ```
@@ -240,11 +239,11 @@ There is also the possibility of being selective in gp-styles:
 dfHRQoL %>% 
   filter(group == "Sweden") %>% 
   forestplot(labeltext = c(labeltext, est), 
-             txt_gp = fpTxtGp(label = list(gpar(fontfamily = rev(font)),
+             txt_gp = fpTxtGp(label = list(gpar(fontfamily = "mono"),
                                            gpar(fontfamily = "",
                                                 col = "#660000")),
                               ticks = gpar(fontfamily = "", cex = 1),
-                              xlab  = gpar(fontfamily = "HersheySerif", cex = 1.5)),
+                              xlab  = gpar(fontfamily = "serif", cex = 1.5)),
              col = clrs,
              xlab = "EQ-5D index")
 ```


### PR DESCRIPTION
* Changed function so that it returns a `gforge_forestplot` object instead of directly plotting. The `print.gforge_forestplot` calls the draw function that converts the object to the actual forestplot. **Breaking** if you have used the function within loops this will cause a break in the old behavior.
* Implemented `dplyr` compatible API that allows using standard dplyr syntax
* Fixed shapes_gp legend bug